### PR TITLE
1.1.0

### DIFF
--- a/Editor/Scripts/Inspectors/Input/OscReceiverInspector.cs
+++ b/Editor/Scripts/Inspectors/Input/OscReceiverInspector.cs
@@ -16,6 +16,7 @@ namespace OscCore
         SerializedProperty m_PortProp;
         
         bool m_ShowAddressFoldout;
+        bool m_PreviouslyRunning;
         
         void OnEnable()
         {
@@ -24,8 +25,6 @@ namespace OscCore
             
             SortAddresses();
         }
-
-        bool m_PreviouslyRunning;
 
         public override void OnInspectorGUI()
         {

--- a/Editor/Scripts/Inspectors/Input/OscReceiverInspector.cs
+++ b/Editor/Scripts/Inspectors/Input/OscReceiverInspector.cs
@@ -25,24 +25,33 @@ namespace OscCore
             SortAddresses();
         }
 
+        bool m_PreviouslyRunning;
+
         public override void OnInspectorGUI()
         {
             var running = m_Target != null && m_Target.Running;
+            if (running != m_PreviouslyRunning)
+                SortAddresses();
+            
+            m_PreviouslyRunning = running;
             
             EditorGUI.BeginDisabledGroup(running && Application.IsPlaying(this));
             EditorGUILayout.PropertyField(m_PortProp);
             EditorGUI.EndDisabledGroup();
 
-            var count = CountHandlers();
-            var prefix = m_ShowAddressFoldout ? "Hide" : "Show";
-            m_ShowAddressFoldout = EditorGUILayout.Foldout(m_ShowAddressFoldout, $"{prefix} {count} Listening Addresses", true);
-            
-            if (m_ShowAddressFoldout)
+            using (new EditorGUI.DisabledScope(!running))
             {
-                foreach (var addr in k_SortedAddresses)
-                    EditorGUILayout.LabelField(addr, EditorStyles.miniBoldLabel);
+                var count = CountHandlers();
+                var prefix = m_ShowAddressFoldout ? "Hide" : "Show";
+                m_ShowAddressFoldout = EditorGUILayout.Foldout(m_ShowAddressFoldout, $"{prefix} {count} Listening Addresses", true);
+            
+                if (m_ShowAddressFoldout)
+                {
+                    foreach (var addr in k_SortedAddresses)
+                        EditorGUILayout.LabelField(addr, EditorStyles.miniBoldLabel);
+                }
             }
-
+           
             serializedObject.ApplyModifiedProperties();
             
             if (EditorHelp.Show)

--- a/Editor/Scripts/Inspectors/Output/PropertyOutputInspector.cs
+++ b/Editor/Scripts/Inspectors/Output/PropertyOutputInspector.cs
@@ -10,6 +10,16 @@ namespace OscCore
     [CustomEditor(typeof(PropertyOutput), true)]
     class PropertyOutputInspector : Editor
     {
+        class MemberInfoComparer : IComparer<MemberInfo>
+        {
+            public int Compare(MemberInfo x, MemberInfo y)
+            {
+                return string.Compare(x?.Name, y?.Name, StringComparison.Ordinal);
+            }
+        }
+
+        static readonly MemberInfoComparer k_MemberComparer = new MemberInfoComparer();
+        
         static readonly GUIContent k_EmptyContent = new GUIContent();
         static readonly GUIContent k_PropTypeContent = new GUIContent("Type", "The type of the selected property");
         static readonly GUIContent k_ComponentContent = new GUIContent("Component", 
@@ -41,7 +51,6 @@ namespace OscCore
         string m_PreviousComponentName;
         int m_ComponentIndex;
 
-        PropertyInfo[] m_Properties;
         MemberInfo[] m_PropertiesAndFields;
         string[] m_PropertyNames;
         int m_PropertyIndex;
@@ -223,7 +232,6 @@ namespace OscCore
             }
         }
 
-
         void DrawVector3ElementFilter()
         {
             using (new EditorGUILayout.HorizontalScope())
@@ -290,14 +298,6 @@ namespace OscCore
             m_PreviousVec2FilterEnumValue = enumValueIndex;
         }
 
-        void GetComponentProperties()
-        {
-            var comp = m_CachedComponents[m_ComponentIndex];
-            var properties = comp.GetType().GetProperties();
-            m_Properties = properties.Where(p => k_SupportedTypes.Contains(p.PropertyType.FullName)).ToArray();
-            m_PropertyNames = m_Properties.Select(m => m.Name).ToArray();
-        }
-
         void GetComponentFieldsAndProperties()
         {
             var comp = m_CachedComponents[m_ComponentIndex];
@@ -323,14 +323,15 @@ namespace OscCore
                 m_PropertiesAndFields[i] = fields[i - fieldsStart];
             }
             
+            Array.Sort(m_PropertiesAndFields, k_MemberComparer);
             m_PropertyNames = m_PropertiesAndFields.Select(m => m.Name).ToArray();
         }
-        
+
         void CleanComponents()
         {
             m_CachedComponents = null;
             m_CachedComponentNames = null;
-            m_Properties = null;
+            m_PropertiesAndFields = null;
             m_PropertyNames = null;
             m_ComponentIndex = -1;
             m_PropertyIndex = -1;

--- a/Editor/Scripts/MonitorWindow.cs
+++ b/Editor/Scripts/MonitorWindow.cs
@@ -139,7 +139,6 @@ namespace OscCore
             if(m_NeedsRepaint) Repaint();
         }
 
-
         public void OnGUI()
         {
             const string noServerWarning = "No OSC Servers are currently active, so no messages can be received";
@@ -188,7 +187,6 @@ namespace OscCore
         [MenuItem("Window/OscCore/Monitor")]
         static void InitWindow()
         {
-            
             ((MonitorWindow) GetWindow(typeof(MonitorWindow)))?.Show();
         }
     }

--- a/Runtime/Scenes/Property Sender Example.unity
+++ b/Runtime/Scenes/Property Sender Example.unity
@@ -54,7 +54,7 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 0
   m_LightmapEditorSettings:
-    serializedVersion: 12
+    serializedVersion: 10
     m_Resolution: 2
     m_BakeResolution: 10
     m_AtlasSize: 512
@@ -62,7 +62,6 @@ LightmapSettings:
     m_AOMaxDistance: 1
     m_CompAOExponent: 1
     m_CompAOExponentDirect: 0
-    m_ExtractAmbientOcclusion: 0
     m_Padding: 2
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
@@ -77,16 +76,10 @@ LightmapSettings:
     m_PVRDirectSampleCount: 32
     m_PVRSampleCount: 256
     m_PVRBounces: 2
-    m_PVREnvironmentSampleCount: 256
-    m_PVREnvironmentReferencePointCount: 2048
-    m_PVRFilteringMode: 2
-    m_PVRDenoiserTypeDirect: 0
-    m_PVRDenoiserTypeIndirect: 0
-    m_PVRDenoiserTypeAO: 0
     m_PVRFilterTypeDirect: 0
     m_PVRFilterTypeIndirect: 0
     m_PVRFilterTypeAO: 0
-    m_PVREnvironmentMIS: 0
+    m_PVRFilteringMode: 2
     m_PVRCulling: 1
     m_PVRFilteringGaussRadiusDirect: 1
     m_PVRFilteringGaussRadiusIndirect: 5
@@ -94,9 +87,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaDirect: 0.5
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
-    m_ExportTrainingData: 0
-    m_TrainingDataDestination: TrainingData
-    m_LightProbeSampleCountMultiplier: 4
+    m_ShowResolutionOverlay: 1
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 1
 --- !u!196 &4
@@ -146,14 +137,12 @@ Light:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 170076733}
   m_Enabled: 1
-  serializedVersion: 10
+  serializedVersion: 8
   m_Type: 1
-  m_Shape: 0
   m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
   m_Intensity: 0.3
   m_Range: 10
   m_SpotAngle: 30
-  m_InnerSpotAngle: 21.80208
   m_CookieSize: 10
   m_Shadows:
     m_Type: 2
@@ -163,24 +152,6 @@ Light:
     m_Bias: 0.05
     m_NormalBias: 0.4
     m_NearPlane: 0.2
-    m_CullingMatrixOverride:
-      e00: 1
-      e01: 0
-      e02: 0
-      e03: 0
-      e10: 0
-      e11: 1
-      e12: 0
-      e13: 0
-      e20: 0
-      e21: 0
-      e22: 1
-      e23: 0
-      e30: 0
-      e31: 0
-      e32: 0
-      e33: 1
-    m_UseCullingMatrixOverride: 0
   m_Cookie: {fileID: 0}
   m_DrawHalo: 0
   m_Flare: {fileID: 0}
@@ -188,15 +159,12 @@ Light:
   m_CullingMask:
     serializedVersion: 2
     m_Bits: 4294967295
-  m_RenderingLayerMask: 1
   m_Lightmapping: 4
   m_LightShadowCasterMode: 0
   m_AreaSize: {x: 0.52, y: 0.22}
   m_BounceIntensity: 1
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
-  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
-  m_UseBoundingSphereOverride: 0
   m_ShadowRadius: 0
   m_ShadowAngle: 0
 --- !u!4 &170076735
@@ -251,10 +219,9 @@ Camera:
   m_ClearFlags: 1
   m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
   m_projectionMatrixMode: 1
-  m_GateFitMode: 2
-  m_FOVAxisMode: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
+  m_GateFitMode: 2
   m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
@@ -330,9 +297,10 @@ MonoBehaviour:
   m_Sender: {fileID: 1670121833}
   m_Address: /composition/layers/1/video/opacity
   m_Object: {fileID: 170076733}
-  m_SourceComponent: {fileID: 170076734}
-  m_PropertyName: intensity
-  m_PropertyTypeName: Single
+  m_SourceComponent: {fileID: 170076735}
+  m_MemberIsProperty: 1
+  m_PropertyName: childCount
+  m_PropertyTypeName: Int32
   m_SendVector2Elements: 0
   m_SendVector3Elements: 0
 --- !u!4 &1670121832
@@ -379,6 +347,7 @@ MonoBehaviour:
   m_Address: /composition/layers/2/video/opacity
   m_Object: {fileID: 1670121830}
   m_SourceComponent: {fileID: 1670121832}
+  m_MemberIsProperty: 1
   m_PropertyName: position
   m_PropertyTypeName: Vector3
   m_SendVector2Elements: 0

--- a/Runtime/Scripts/Component/OscReceiver.cs
+++ b/Runtime/Scripts/Component/OscReceiver.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using UnityEditor;
 using UnityEngine;
 
 namespace OscCore
@@ -29,8 +30,16 @@ namespace OscCore
 
         void OnEnable()
         {
-            // OnEnable gets called twice when you enter play mode, but we just want one server instance
-            if (Running) return;
+            OnStart();
+        }
+
+        void Awake()
+        {
+            OnStart();
+        }
+
+        void OnStart()
+        {
             Server = OscServer.GetOrCreate(m_Port);
             Running = true;
         }
@@ -45,14 +54,10 @@ namespace OscCore
             Server?.Update();
         }
 
-        void OnDisable()
+        void OnDestroy()
         {
             Server?.Dispose();
-        }
-
-        void OnApplicationQuit()
-        {
-            Server?.Dispose();
+            Server = null;
         }
 
         void SetPort(int newPort)

--- a/Runtime/Scripts/Component/OscReceiver.cs
+++ b/Runtime/Scripts/Component/OscReceiver.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using UnityEditor;
 using UnityEngine;
 
 namespace OscCore

--- a/Runtime/Scripts/Component/Output/PropertyOutput.cs
+++ b/Runtime/Scripts/Component/Output/PropertyOutput.cs
@@ -165,8 +165,11 @@ namespace OscCore
             switch (m_SendVector3Elements)
             {
                 case Vector3ElementFilter.XYZ:
-                    if(!m_PreviousVec3Value.Equals(vec))
+                    if (!m_PreviousVec3Value.Equals(vec))
+                    {
+                        m_PreviousVec3Value = vec;
                         m_Sender.Client.Send(m_Address, vec);
+                    }
                     break;
                 case Vector3ElementFilter.X:
                     if (!m_PreviousSingleValue.Equals(vec.x))
@@ -207,8 +210,11 @@ namespace OscCore
                     break;
                 case Vector3ElementFilter.YZ:
                     var yz = new Vector2(vec.y, vec.z);
-                    if(!m_PreviousVec2Value.Equals(yz))
+                    if (!m_PreviousVec2Value.Equals(yz))
+                    {
+                        m_PreviousVec2Value = yz;
                         m_Sender.Client.Send(m_Address, yz);
+                    }
                     break;
             }
         }

--- a/Runtime/Scripts/Component/Output/PropertyOutput.cs
+++ b/Runtime/Scripts/Component/Output/PropertyOutput.cs
@@ -201,7 +201,7 @@ namespace OscCore
                     }
                     break;
                 case Vector3ElementFilter.XZ:
-                    var xz = new Vector2(vec.x, vec.y);
+                    var xz = new Vector2(vec.x, vec.z);
                     if (!m_PreviousVec2Value.Equals(xz))
                     {
                         m_PreviousVec2Value = xz;

--- a/Runtime/Scripts/Component/Output/PropertyOutput.cs
+++ b/Runtime/Scripts/Component/Output/PropertyOutput.cs
@@ -19,6 +19,7 @@ namespace OscCore
         [SerializeField] GameObject m_Object;
         [SerializeField] Component m_SourceComponent;
         
+        [SerializeField] bool m_MemberIsProperty;
         [SerializeField] string m_PropertyName;
         [SerializeField] string m_PropertyTypeName;
         
@@ -37,6 +38,10 @@ namespace OscCore
         Vector3 m_PreviousVec3Value;
 
         bool m_HasSender;
+
+        MemberInfo m_MemberInfo;
+        PropertyInfo m_Property;
+        FieldInfo m_Field;
         
         /// <summary>
         /// The OscCore component that handles serializing and sending messages. Cannot be null
@@ -56,11 +61,41 @@ namespace OscCore
             get => m_SourceComponent;
             set => m_SourceComponent = value == null ? m_SourceComponent : value;
         }
+        
+        /// <summary>The member to send the value of</summary>
+        public MemberInfo Member => m_MemberInfo;
 
         /// <summary>
-        /// The property to send the value of.  Must be a property found on the current SourceComponent
+        /// The property to send the value of.  Must be a property found on the current SourceComponent.
+        /// Will be null if the member being sent is a Field.
         /// </summary>
-        public PropertyInfo Property { get; set; }
+        public PropertyInfo Property
+        {
+            get => m_Property;
+            set
+            {
+                m_MemberInfo = value;
+                m_Property = value;
+                m_Field = null;
+                m_MemberIsProperty = true;
+            }
+        }
+
+        /// <summary>
+        /// The Field to send the value of.  Must be a public field found on the current SourceComponent.
+        /// Will be null if the member being sent is a Property.
+        /// </summary>
+        public FieldInfo Field
+        {
+            get => m_Field;
+            set
+            {
+                m_MemberInfo = value;
+                m_Field = value;
+                m_Property = null;
+                m_MemberIsProperty = false;
+            }
+        }
 
         void OnEnable()
         {
@@ -78,10 +113,10 @@ namespace OscCore
 
         void Update()
         {
-            if (Property == null || !m_HasSender || m_Sender.Client == null) 
+            if (m_MemberInfo == null || !m_HasSender || m_Sender.Client == null) 
                 return;
-            
-            var value = Property.GetValue(m_SourceComponent);
+
+            var value = m_MemberIsProperty ? m_Property.GetValue(m_SourceComponent) : m_Field.GetValue(m_SourceComponent);
             if (value == null)
                 return;
             
@@ -242,7 +277,11 @@ namespace OscCore
                 return;
             
             var type = m_SourceComponent.GetType();
-            Property = type.GetProperty(m_PropertyName);
+
+            if(m_MemberIsProperty)
+                Property = type.GetProperty(m_PropertyName);
+            else
+                Field = type.GetField(m_PropertyName);
         }
     }
 }

--- a/Runtime/Scripts/Component/Output/PropertyOutput.cs
+++ b/Runtime/Scripts/Component/Output/PropertyOutput.cs
@@ -62,9 +62,6 @@ namespace OscCore
             set => m_SourceComponent = value == null ? m_SourceComponent : value;
         }
         
-        /// <summary>The member to send the value of</summary>
-        public MemberInfo Member => m_MemberInfo;
-
         /// <summary>
         /// The property to send the value of.  Must be a property found on the current SourceComponent.
         /// Will be null if the member being sent is a Field.

--- a/Runtime/Scripts/OscServer.cs
+++ b/Runtime/Scripts/OscServer.cs
@@ -34,6 +34,8 @@ namespace OscCore
         
         readonly List<OscActionPair> m_PatternMatchedMethods = new List<OscActionPair>();
         
+        internal bool Running { get; set; }
+
         /// <summary>
         /// Map from port number to the server that handles incoming messages for it
         /// </summary>
@@ -67,12 +69,17 @@ namespace OscCore
         public void Start()
         {
             // make sure redundant calls don't do anything after the first
-            if (m_Started) return;
+            if (m_Started)
+            {
+                Running = true;
+                return;
+            }
             
             m_Socket.Start();
             
             m_Disposed = false;
             m_Started = true;
+            Running = true;
         }
 
         /// <summary>
@@ -363,34 +370,25 @@ namespace OscCore
         
         public void Dispose()
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        void Dispose(bool disposing)
-        {
+            PortToServer.Remove(Port);
+            
             if (m_Disposed) return;
             m_Disposed = true;
 
-            PortToServer.Remove(Port);
-
             if(m_BufferHandle.IsAllocated) m_BufferHandle.Free();
-            if (disposing)
-            {
-                AddressSpace.AddressToMethod.Dispose();
-                AddressSpace = null;
-                m_Socket.Dispose();
-            }
+            AddressSpace.AddressToMethod.Dispose();
+            AddressSpace = null;
+            m_Socket.Dispose();
         }
 
         ~OscServer()
         {
-            Dispose(true);
+            Dispose();
         }
 
         public int CountHandlers()
         {
-            return AddressSpace.AddressToMethod.SourceToBlob.Count;
+            return AddressSpace?.AddressToMethod.SourceToBlob.Count ?? 0;
         }
     }
 }

--- a/Runtime/Scripts/OscSocket.cs
+++ b/Runtime/Scripts/OscSocket.cs
@@ -41,16 +41,6 @@ namespace OscCore
             m_Started = true;
         }
         
-        public void Pause()
-        {
-            m_Disposed = true;
-        }
-        
-        public void Resume()
-        {
-            m_Disposed = false;
-        }
-        
         void Serve()
         {
 #if UNITY_EDITOR


### PR DESCRIPTION
# Version 1.1.0

## Improvements
* `Property Output` now also supports getting values from fields, in addition to the properties it already supported.

## Bug Fixes

* Fix value diffing for a few scenarios in property output.  fixes `Vector3.xz` output and redundant vector3 messages.

* Fix state management for Monitor Window (more reliably reflects the real state of things)

* fix a null reference exception that happened when an `OscReceiver` was disabled