### PR TITLE
Add ReInit Function for dynamic IP targets

### DIFF
--- a/Runtime/Scripts/Component/Output/OscSender.cs
+++ b/Runtime/Scripts/Component/Output/OscSender.cs
@@ -18,9 +18,7 @@ namespace OscCore
         {
             get { return m_IpAddress; }
             set {
-                    bool valid = IPAddress.TryParse(value, out var ip);
-
-                    if(valid != false){
+                    if(IPAddress.TryParse(value, out var ip)){
                         m_IpAddress = value;
                         ReInitialize();
                     }

--- a/Runtime/Scripts/Component/Output/OscSender.cs
+++ b/Runtime/Scripts/Component/Output/OscSender.cs
@@ -52,6 +52,9 @@ namespace OscCore
                 Client = new OscClient(m_IpAddress, m_Port);
         }
 
+        /// <summary>
+        /// Reinitializes the client. Use this if the IP or port change and the client needs to restart.
+        /// </summary>
         public void ReInit()
         {
             Client = null;

--- a/Runtime/Scripts/Component/Output/OscSender.cs
+++ b/Runtime/Scripts/Component/Output/OscSender.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using System.Net;
 
 namespace OscCore
 {
@@ -17,11 +18,11 @@ namespace OscCore
         {
             get { return m_IpAddress; }
             set {
-                    string[] ipString = value.Split('.');
+                    bool valid = IPAddress.TryParse(value, out var ip);
 
-                    if(ipString.Length == 4){
+                    if(valid != false){
                         m_IpAddress = value;
-                        ReInit();
+                        ReInitialize();
                     }
                 }
         }
@@ -32,8 +33,7 @@ namespace OscCore
             get { return m_Port; }
             set { 
                     m_Port = value;
-                    ReInit();
- 
+                    ReInitialize();
                 }
         }
         
@@ -63,10 +63,7 @@ namespace OscCore
                 Client = new OscClient(m_IpAddress, m_Port);
         }
 
-        /// <summary>
-        /// Reinitializes the client. Use this if the IP or port change and the client needs to restart.
-        /// </summary>
-        public void ReInit()
+        void ReInitialize()
         {
             Client = null;
             Setup();

--- a/Runtime/Scripts/Component/Output/OscSender.cs
+++ b/Runtime/Scripts/Component/Output/OscSender.cs
@@ -7,16 +7,24 @@ namespace OscCore
     public class OscSender : MonoBehaviour
     {
         [Tooltip("The IP address to send to")]
-        [SerializeField] public string m_IpAddress = "127.0.0.1";
+        [SerializeField] string m_IpAddress = "127.0.0.1";
         
         [Tooltip("The port on the remote IP to send to")]
         [SerializeField] int m_Port = 7000;
 
         /// <summary>The IP address to send to</summary>
-        public string IpAddress => m_IpAddress;
-        
+        public string IpAddress
+        {
+            get { return m_IpAddress; }
+            set { m_IpAddress = value; }
+        }
+
         /// <summary>The port on the remote IP to send to</summary>
-        public int Port => m_Port;
+        public int Port
+        {
+            get { return m_Port; }
+            set { m_Port = value; }
+        }
         
         /// <summary>
         /// Handles serializing and sending messages.  Use methods on this to send messages to the endpoint.

--- a/Runtime/Scripts/Component/Output/OscSender.cs
+++ b/Runtime/Scripts/Component/Output/OscSender.cs
@@ -19,7 +19,7 @@ namespace OscCore
             set {
                     string[] ipString = value.Split('.');
 
-                    if(ipString.Length === 4){
+                    if(ipString.Length == 4){
                         m_IpAddress = value;
                         ReInit();
                     }
@@ -33,6 +33,7 @@ namespace OscCore
             set { 
                     m_Port = value;
                     ReInit();
+ 
                 }
         }
         

--- a/Runtime/Scripts/Component/Output/OscSender.cs
+++ b/Runtime/Scripts/Component/Output/OscSender.cs
@@ -16,7 +16,14 @@ namespace OscCore
         public string IpAddress
         {
             get { return m_IpAddress; }
-            set { m_IpAddress = value; }
+            set {
+                    string[] ipString = value.Split('.');
+
+                    if(ipString.Length === 4){
+                        m_IpAddress = value;
+                        ReInit();
+                    }
+                }
         }
 
         /// <summary>The port on the remote IP to send to</summary>

--- a/Runtime/Scripts/Component/Output/OscSender.cs
+++ b/Runtime/Scripts/Component/Output/OscSender.cs
@@ -7,7 +7,7 @@ namespace OscCore
     public class OscSender : MonoBehaviour
     {
         [Tooltip("The IP address to send to")]
-        [SerializeField] string m_IpAddress = "127.0.0.1";
+        [SerializeField] public string m_IpAddress = "127.0.0.1";
         
         [Tooltip("The port on the remote IP to send to")]
         [SerializeField] int m_Port = 7000;

--- a/Runtime/Scripts/Component/Output/OscSender.cs
+++ b/Runtime/Scripts/Component/Output/OscSender.cs
@@ -43,6 +43,12 @@ namespace OscCore
             if(Client == null)
                 Client = new OscClient(m_IpAddress, m_Port);
         }
+
+        public void ReInit()
+        {
+            Client = null;
+            Setup();
+        }
     }
 }
 

--- a/Runtime/Scripts/Component/Output/OscSender.cs
+++ b/Runtime/Scripts/Component/Output/OscSender.cs
@@ -30,7 +30,10 @@ namespace OscCore
         public int Port
         {
             get { return m_Port; }
-            set { m_Port = value; }
+            set { 
+                    m_Port = value;
+                    ReInit();
+                }
         }
         
         /// <summary>


### PR DESCRIPTION
I was adding an input control to my project for the IP of the OscSender component and needed a way to reinitialize the client. The value of the input is sent to the component's `m_IpAddress` string, then it runs Setup() again.

I have a Property Output controller script that is doing the following to reinitilize the client and connect to the new IP.

```    
public void changeOSCIP(string message)
    {
        OSCSender.m_IpAddress = message;
        OSCSender.ReInit();
    }
```

The input component then sends it's value to the above function when users finishes editing the input field. 

One thing to note that may not be ideal, the m_IpAddress object is set public in this PR. When redefining the pubic `IpAddress` string, it fails to use the new IP in the setup function unless changes happen to `m_IpAddress` directly.  Maybe I'm just doing this wrong. And maybe my controller script can just do this on it's own by setting the client null and running Setup. The IP still fails to update though. Would really appreciate any thoughts. :) 


![IMG_9556](https://user-images.githubusercontent.com/8985705/76263446-eb100480-622c-11ea-8934-34bc64bb4ce5.PNG)



