### PR TITLE
tags parsing includes ',' when determining size of tags in packet

### DIFF
--- a/Runtime/Scripts/OscParser.cs
+++ b/Runtime/Scripts/OscParser.cs
@@ -51,8 +51,8 @@ namespace OscCore
             if (alignedAddressLength == addressLength)
                 alignedAddressLength += 4;
 
-            var tagCount = ParseTags(Buffer, alignedAddressLength);
-            var offset = alignedAddressLength + (tagCount + 4) & ~3;
+            var tagSize = ParseTags(Buffer, alignedAddressLength);
+            var offset = alignedAddressLength + (tagSize + 4) & ~3;
             FindOffsets(offset);
             return addressLength;
         }
@@ -76,8 +76,8 @@ namespace OscCore
                 alignedAddressLength += 4;
 
             var startPlusAlignedLength = startingByteOffset + alignedAddressLength;
-            var tagCount = ParseTags(Buffer, startPlusAlignedLength);
-            var offset = startPlusAlignedLength + (tagCount + 4) & ~3;
+            var tagSize = ParseTags(Buffer, startPlusAlignedLength);
+            var offset = startPlusAlignedLength + (tagSize + 4) & ~3;
             FindOffsets(offset);
             return addressLength;
         }
@@ -165,6 +165,7 @@ namespace OscCore
             return AddressType.Pattern;
         }
 
+        /// <returns> Size of tags in bytes, including ',' </returns>
         internal int ParseTags(byte[] bytes, int start = 0)
         {
             if (bytes[start] != Constant.Comma) return 0;
@@ -182,7 +183,8 @@ namespace OscCore
             }
 
             MessageValues.ElementCount = outIndex;
-            return outIndex;
+
+            return outIndex + 1; // +1 includes the starting ',' in the tagSize
         }
 
         public int FindUnalignedAddressLength()

--- a/Tests/Editor/ParsingTests.cs
+++ b/Tests/Editor/ParsingTests.cs
@@ -37,7 +37,8 @@ namespace OscCore.Tests
         [TestCaseSource(typeof(TagsTestData), nameof(TagsTestData.StandardTagParseCases))]
         public void SimpleTagParsing(TypeTagParseTestCase test)
         {
-            var tagCount = m_Parser.ParseTags(test.Bytes, test.Start);
+            var tagSize = m_Parser.ParseTags(test.Bytes, test.Start);
+            var tagCount = tagSize - 1; // remove ','
             
             Assert.AreEqual(test.Expected.Length, tagCount);
             var tags = m_Parser.MessageValues.Tags;


### PR DESCRIPTION
I was using OscCore to send Vector3s; position and rotation. The values seemed to be sent correctly. However, the received x value was always 0. The received Y was the sent X. Z was Y.

What corrected it for me was changing the byte alignment of the tags parsing. ',fff' was being treated as 3 bytes when it was really 4. The ',' wasn't being counted. Working with the tag size, instead of the count, corrected how the Vector3s were received.
