### PR TITLE
Move server thread execution loop to a try/finally to avoid queue buildup

### DIFF
--- a/Runtime/Scripts/OscServer.cs
+++ b/Runtime/Scripts/OscServer.cs
@@ -204,12 +204,17 @@ namespace OscCore
         /// <summary>Must be called on the main thread every frame to handle queued events</summary>
         public void Update()
         {
-            for (int i = 0; i < m_MainThreadCount; i++)
+            try
             {
-                m_MainThreadQueue[i]();
+                for (int i = 0; i < m_MainThreadCount; i++)
+                {
+                    m_MainThreadQueue[i]();
+                }
             }
-            
-            m_MainThreadCount = 0;
+            finally    // Chances are, if we run into an exception, we'll be looping forever
+            {
+                m_MainThreadCount = 0;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Moved OscServer thread execution loop to a try/finally block to avoid exceptions preventing the queue from being cleared after execution. Before this, if a single delegate in the execution array consistently threw an exception, the loop would never get cleared